### PR TITLE
Use project display name instead of project name

### DIFF
--- a/popcornguineapigplugin/src/main/kotlin/com/github/codandotv/popcorn/presentation/tasks/PopcornTask.kt
+++ b/popcornguineapigplugin/src/main/kotlin/com/github/codandotv/popcorn/presentation/tasks/PopcornTask.kt
@@ -45,7 +45,7 @@ open class PopcornTask : DefaultTask() {
 
     @TaskAction
     fun process() {
-        logger.popcornLoggerInfo("Process popcorn task over ${project.name.orEmpty()}")
+        logger.popcornLoggerInfo("Process popcorn task over ${project.displayName.orEmpty()}")
 
         val internalProjectDependencies = project.internalProjectDependencies(
             configurationName = getRightConfigurationNameUseCase.execute(configuration.project.type),
@@ -53,7 +53,7 @@ open class PopcornTask : DefaultTask() {
         )
 
         val targetModule = TargetModule(
-            moduleName = project.name,
+            moduleName = project.displayName,
             internalDependencies = internalProjectDependencies
         )
 


### PR DESCRIPTION
# Use project display name instead of project name

## Description 📑
Current implementation of PopCorn tasks uses the project name to log progress, which results in non-informative logs for nested projects:

<img width="949" alt="image" src="https://github.com/user-attachments/assets/22e76f08-0622-4b29-ad5e-ab7158544551" />


Real world projects are usually structured like this:

feature:
-data
-presentation
-domain

Most devs would expect the logger to print `:feature:data` and not `:data`. This pr addresses this issue

With this change logs look like this:
<img width="981" alt="image" src="https://github.com/user-attachments/assets/862ea675-ab4c-4e84-ae12-7af9b40efcf3" />

## Issues 🔖
- Issue 01 -> https://issues/here
- Issue 02 -> https://issues/here2

--

## Screenshots or Videos 📸
- n/a

