### PR TITLE
Add warnings for disabling configuration cache in Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ naming conventions to your advantage.
 ./gradlew popcornParent
 ```
 
+⚠️ If your project is using cache for **configuration phase**, it is necessary to run popcorngp in this way:
+
+```sh
+./gradlew popcornParent --no-configuration-cache
+```
+
 It is simple as a popcorn 🍿 + 🐹
 
 ## 🎯 Supported Project Types

--- a/docs/1-getting-started.md
+++ b/docs/1-getting-started.md
@@ -113,6 +113,12 @@ plugins {
 ./gradlew popcornParent
 ```
 
+!!!warning "For Gradle projects with Cache enabled for the  Configuration Phase"
+    In case your project has cache enabled for the Gradle configuration phase, you need to disable that for popcorngp. So your command should be:
+    ```sh
+    ./gradlew popcornParent --no-configuration-cache
+    ```
+
 ---
 
 It is simple as a popcorn 🍿 + 🐹


### PR DESCRIPTION
Provide guidance on running Popcorn with the configuration cache disabled to ensure proper functionality. Include warnings in the documentation to inform users about the necessity of this adjustment when using Gradle.

- Closes https://github.com/CodandoTV/popcorn-guineapig/issues/76

